### PR TITLE
fix termination condition of validation accuracy

### DIFF
--- a/src/nn-train.cpp
+++ b/src/nn-train.cpp
@@ -221,8 +221,10 @@ size_t nnet_predict(NNet& nnet, DataSet& data) {
 
 bool isEoutStopDecrease(const std::vector<size_t> Eouts, size_t epoch, size_t nNonIncEpoch) {
 
-  for (size_t i=0; i<nNonIncEpoch; ++i) {
-    if (epoch - i > 0 && Eouts[epoch] > Eouts[epoch - i])
+  if(epoch < nNonIncEpoch) return false;
+
+  for (size_t i=1; i<=nNonIncEpoch; ++i) {
+    if (epoch - i > 0 && Eouts[epoch] < Eouts[epoch - i]) // Eout is # error instances
       return false;
   }
 

--- a/src/nn-train.cpp
+++ b/src/nn-train.cpp
@@ -224,7 +224,7 @@ bool isEoutStopDecrease(const std::vector<size_t> Eouts, size_t epoch, size_t nN
   if(epoch < nNonIncEpoch) return false;
 
   for (size_t i=1; i<=nNonIncEpoch; ++i) {
-    if (epoch - i > 0 && Eouts[epoch] < Eouts[epoch - i]) // Eout is # error instances
+    if (Eouts[epoch] < Eouts[epoch - i]) // Eout is # error instances
       return false;
   }
 


### PR DESCRIPTION
I think there is something wrong on the termination condition of training epochs. I used the default configuration("When the accuracy on validation set doesn't go upfor 6 epochs, the training procedure would stop.") and got something like:

```
._______._________________________._________________________.___________.
|       |                         |                         |           |
|       |        In-Sample        |      Out-of-Sample      |  Elapsed  |
| Epoch |__________.______________|__________.______________|   Time    |
|       |          |              |          |              | (seconds) |
|       | Accuracy | # of correct | Accuracy | # of correct |           |
|_______|__________|______________|__________|______________|___________|
|   0   |  61.55 % |    13294     |  62.06 % |     3351     |      5.93 |
|   1   |  63.30 % |    13672     |  62.80 % |     3391     |      5.97 |
|   2   |  64.56 % |    13944     |  63.61 % |     3435     |      5.96 |
|   3   |  65.77 % |    14207     |  64.39 % |     3477     |      6.01 |
|   4   |  66.91 % |    14453     |  65.31 % |     3527     |      5.98 |
|   5   |  67.97 % |    14681     |  65.63 % |     3544     |      5.99 |
|_______|__________|______________|__________|______________|___________|
```

The validation accuracy was still increasing but the training procedure was terminated.
I found out that this is due to the return value of isEoutStopDecrease() in nn-train.cpp. From my understanding, Eout is the number of **wrong** predictions, so Eouts[epoch] shoud be **less than** Eouts[epoch - i] to indicate that the validation accuracy **increases**. This problem does not occur in the example scripts since the --min-acc option is set in those commands.

I tried to fix it and made this pull request. However, I am not sure whether this matches your original logic. Thank you very much for checking this :)
